### PR TITLE
Remove next branch

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -99,10 +99,7 @@ require('packer').startup(
 			config = require'eviline',
 			requires = {'kyazdani42/nvim-web-devicons', opt = true}
 		}
-		use {
-			'scalameta/nvim-metals',
-			branch = 'next',
-		}
+		use 'scalameta/nvim-metals'
 	end
 )
 


### PR DESCRIPTION
Hello! I just removed the next branch from nvim-metals as I'll only be sticking to `main` and instead ensure that stays compatible. I did a quick search and only found a couple repos using `next` anyways so figured I'd give you a heads up.